### PR TITLE
Fix missing build tools

### DIFF
--- a/3.6/Dockerfile
+++ b/3.6/Dockerfile
@@ -16,10 +16,12 @@ RUN apt-get update \
     && apt-get upgrade --quiet --yes \
     && apt-get update --quiet \
     && apt-get install --quiet --yes \
+        build-essential \
         curl \
         locales \
         python${PYTHON_VERSION} \
-        python3-distutils \
+        python${PYTHON_VERSION}-dev \
+        python${PYTHON_VERSION}-distutils \
         python${PYTHON_VERSION}-venv \
         software-properties-common \
         tzdata \

--- a/3.7/Dockerfile
+++ b/3.7/Dockerfile
@@ -16,10 +16,12 @@ RUN apt-get update \
     && apt-get upgrade --quiet --yes \
     && apt-get update --quiet \
     && apt-get install --quiet --yes \
+        build-essential \
         curl \
         locales \
         python${PYTHON_VERSION} \
-        python3-distutils \
+        python${PYTHON_VERSION}-dev \
+        python${PYTHON_VERSION}-distutils \
         python${PYTHON_VERSION}-venv \
         software-properties-common \
         tzdata \

--- a/3.8/Dockerfile
+++ b/3.8/Dockerfile
@@ -16,10 +16,12 @@ RUN apt-get update \
     && apt-get upgrade --quiet --yes \
     && apt-get update --quiet \
     && apt-get install --quiet --yes \
+        build-essential \
         curl \
         locales \
         python${PYTHON_VERSION} \
-        python3-distutils \
+        python${PYTHON_VERSION}-dev \
+        python${PYTHON_VERSION}-distutils \
         python${PYTHON_VERSION}-venv \
         software-properties-common \
         tzdata \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.0.1
+
+- feature: add `publish` and `tag` targets to `Makefile` to make images publishing easier
+- fix: add `build-essentials` and Python header files and static library to improve compatibility with some wheels (eg. [thriftpy2](https://github.com/Thriftpy/thriftpy2) which needs gcc and Python header files)
+
 ## 2.0.0
 
 - feature: add image for Python 3.8 (issue #3)

--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,7 @@ clean:
 	for VERSION in $(VERSIONS); do \
 		docker image rm -f $(COMPOSE_BUILD_NAME):$$VERSION; \
 	done
+
+.PHONY:clean-tests
+clean-test:
+	rm -rf test_pipenv test_poetry

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 BUILD_NAME=python
+OWNER=groovytron
 COMPOSE_BUILD_NAME=python-container
 VERSIONS=3.8 3.7 3.6
+LATEST=3.8
+LATEST_LABEL=latest
 ALL=$(addprefix python,$(VERSIONS))
 VCS_REF="$(shell git rev-parse HEAD)"
 BUILD_DATE="$(shell date -u +"%Y-%m-%dT%H:%m:%SZ")"
@@ -22,6 +25,20 @@ clean:
 	for VERSION in $(VERSIONS); do \
 		docker image rm -f $(COMPOSE_BUILD_NAME):$$VERSION; \
 	done
+
+.PHONY:tag
+tag:
+	for VERSION in $(VERSIONS); do \
+		docker tag $(COMPOSE_BUILD_NAME):$$VERSION $(OWNER)/$(BUILD_NAME):$$VERSION; \
+	done && \
+	docker tag $(COMPOSE_BUILD_NAME):$(LATEST) $(OWNER)/$(BUILD_NAME):$(LATEST_LABEL)
+
+.PHONY:publish
+publish: tag
+	for VERSION in $(VERSIONS); do \
+		docker push $(OWNER)/$(BUILD_NAME):$$VERSION; \
+	done && \
+	docker push $(OWNER)/$(BUILD_NAME):$(LATEST_LABEL)
 
 .PHONY:clean-tests
 clean-test:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ Docker container allowing you to build and test your Python project. _This conta
 
 [`poetry`](https://python-poetry.org/) is installed in every image to make Python dependencies installation easier. [`pipenv`](https://github.com/pypa/pipenv) is also installed if you prefer to use this solution for dependencies management.
 
+The following dependencies are installed to make wheel installation work properly:
+
+- [build-essentials](https://packages.ubuntu.com/bionic/build-essential) (`g++`, `gcc`, `make` and `libc6-dev`)
+- [python-dev](https://packages.ubuntu.com/bionic-updates/python3.8-dev) (header files and static library for Python)
+
 ## Use the container
 
 We recommend you use the `dev` user instead of `root` when running that container.


### PR DESCRIPTION
- add Python header files and static library to images
- add `build-essentials` package to images

This mainly fixes installation errors of wheels like [thriftpy2](https://github.com/Thriftpy/thriftpy2) which need `gcc` and Python header fiels and static library.